### PR TITLE
CI: Force pull latest Docker base images

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           context: ./OmniForge.DotNet
           file: ./OmniForge.DotNet/Dockerfile
+          pull: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -101,6 +101,7 @@ jobs:
         with:
           context: ./OmniForge.DotNet
           file: ./OmniForge.DotNet/Dockerfile
+          pull: true
           push: false
           tags: omniforge-dotnet:pr-${{ github.event.pull_request.number }}
           cache-from: type=gha


### PR DESCRIPTION
Updates the GitHub Actions workflows (`deploy-production.yml` and `pr-validation.yml`) to explicitly pull the latest versions of the Docker base images (`mcr.microsoft.com/dotnet/sdk:9.0` and `aspnet:9.0`) during the build process. This ensures that the pipeline always uses the most up-to-date .NET 9 SDK and runtime, avoiding issues with stale cached images.