### PR TITLE
Fix DI validation crash (keep scheduler singleton; scope sender deps)

### DIFF
--- a/OmniForge.DotNet/src/OmniForge.Infrastructure/DependencyInjection.cs
+++ b/OmniForge.DotNet/src/OmniForge.Infrastructure/DependencyInjection.cs
@@ -110,8 +110,8 @@ namespace OmniForge.Infrastructure
 
             // EventSub Event Handlers (Strategy Pattern)
             services.AddSingleton<IDiscordNotificationTracker, DiscordNotificationTracker>();
-            services.AddScoped<IDiscordInviteBroadcastScheduler, DiscordInviteBroadcastScheduler>();
-            services.AddScoped<IDiscordInviteSender, DiscordInviteSender>();
+            services.AddSingleton<IDiscordInviteBroadcastScheduler, DiscordInviteBroadcastScheduler>();
+            services.AddSingleton<IDiscordInviteSender, DiscordInviteSender>();
             services.AddScoped<IEventSubHandler, StreamOnlineHandler>();
             services.AddScoped<IEventSubHandler, StreamOfflineHandler>();
             services.AddScoped<IEventSubHandler, FollowHandler>();

--- a/OmniForge.DotNet/tests/OmniForge.Tests/EventHandlers/SupportingClassTests.cs
+++ b/OmniForge.DotNet/tests/OmniForge.Tests/EventHandlers/SupportingClassTests.cs
@@ -181,6 +181,8 @@ namespace OmniForge.Tests.EventHandlers
             _mockScopeFactory.Setup(x => x.CreateScope()).Returns(_mockScope.Object);
             _mockScope.Setup(x => x.ServiceProvider).Returns(_mockServiceProvider.Object);
             _mockServiceProvider.Setup(x => x.GetService(typeof(IUserRepository))).Returns(_mockUserRepository.Object);
+            _mockServiceProvider.Setup(x => x.GetService(typeof(ITwitchBotEligibilityService))).Returns(_mockBotEligibilityService.Object);
+            _mockServiceProvider.Setup(x => x.GetService(typeof(ITwitchApiService))).Returns(_mockTwitchApiService.Object);
         }
 
         [Fact]
@@ -194,9 +196,7 @@ namespace OmniForge.Tests.EventHandlers
                 _mockScopeFactory.Object,
                 _mockLogger.Object,
                 _mockTracker.Object,
-                _mockMonitoringRegistry.Object,
-                _mockBotEligibilityService.Object,
-                _mockTwitchApiService.Object);
+                _mockMonitoringRegistry.Object);
 
             // Act
             await sender.SendDiscordInviteAsync("123");
@@ -218,9 +218,7 @@ namespace OmniForge.Tests.EventHandlers
                 _mockScopeFactory.Object,
                 _mockLogger.Object,
                 _mockTracker.Object,
-                _mockMonitoringRegistry.Object,
-                _mockBotEligibilityService.Object,
-                _mockTwitchApiService.Object);
+                _mockMonitoringRegistry.Object);
 
             // Act
             await sender.SendDiscordInviteAsync("123");
@@ -249,9 +247,7 @@ namespace OmniForge.Tests.EventHandlers
                 _mockScopeFactory.Object,
                 _mockLogger.Object,
                 _mockTracker.Object,
-                _mockMonitoringRegistry.Object,
-                _mockBotEligibilityService.Object,
-                _mockTwitchApiService.Object);
+                _mockMonitoringRegistry.Object);
 
             // Act
             await sender.SendDiscordInviteAsync("123");
@@ -278,9 +274,7 @@ namespace OmniForge.Tests.EventHandlers
                 _mockScopeFactory.Object,
                 _mockLogger.Object,
                 _mockTracker.Object,
-                _mockMonitoringRegistry.Object,
-                _mockBotEligibilityService.Object,
-                _mockTwitchApiService.Object);
+                _mockMonitoringRegistry.Object);
 
             // Act
             await sender.SendDiscordInviteAsync("123");
@@ -312,9 +306,7 @@ namespace OmniForge.Tests.EventHandlers
                 _mockScopeFactory.Object,
                 _mockLogger.Object,
                 _mockTracker.Object,
-                _mockMonitoringRegistry.Object,
-                _mockBotEligibilityService.Object,
-                _mockTwitchApiService.Object);
+                _mockMonitoringRegistry.Object);
 
             // Act
             await sender.SendDiscordInviteAsync("123");
@@ -348,9 +340,7 @@ namespace OmniForge.Tests.EventHandlers
                 _mockScopeFactory.Object,
                 _mockLogger.Object,
                 _mockTracker.Object,
-                _mockMonitoringRegistry.Object,
-                _mockBotEligibilityService.Object,
-                _mockTwitchApiService.Object);
+                _mockMonitoringRegistry.Object);
 
             // Act
             await sender.SendDiscordInviteAsync("123");


### PR DESCRIPTION
## What changed
- Keep `DiscordInviteBroadcastScheduler` as **singleton** so it can safely maintain long-lived background task state.
- Keep `DiscordInviteSender` as **singleton**, but remove direct constructor dependencies on scoped services.
  - It now resolves `ITwitchBotEligibilityService` and `ITwitchApiService` inside a scope created via `IServiceScopeFactory`.

## Why
- Fixes DI validation crash (singleton consuming scoped services) **without** breaking scheduler background loop state.

## Verification
- `dotnet build` (Release) succeeded.
- Unit tests in `SupportingClassTests` passed.