### PR TITLE
Fix per-game counter seeding to prevent extra counters

### DIFF
--- a/OmniForge.DotNet/src/OmniForge.Infrastructure/Services/GameSwitchService.cs
+++ b/OmniForge.DotNet/src/OmniForge.Infrastructure/Services/GameSwitchService.cs
@@ -225,7 +225,12 @@ namespace OmniForge.Infrastructure.Services
             try
             {
                 var loadedCustom = await _gameCustomCountersConfigRepository.GetAsync(userId, gameId);
-                newCustomCountersConfig = loadedCustom ?? activeCustomCounters ?? new CustomCounterConfiguration();
+
+                // IMPORTANT: Do not seed a newly detected game's custom counters from the currently-active game.
+                // Otherwise, switching/adding a game can cause counters from the previous game to appear as
+                // enabled for the new game.
+                newCustomCountersConfig = loadedCustom ?? new CustomCounterConfiguration();
+
                 if (loadedCustom == null)
                 {
                     await _gameCustomCountersConfigRepository.SaveAsync(userId, gameId, newCustomCountersConfig);
@@ -233,8 +238,8 @@ namespace OmniForge.Infrastructure.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "❌ Failed loading game custom counters config for user {UserId} game {GameId}; using active", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(gameId));
-                newCustomCountersConfig = activeCustomCounters ?? new CustomCounterConfiguration();
+                _logger.LogError(ex, "❌ Failed loading game custom counters config for user {UserId} game {GameId}; using empty config", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(gameId));
+                newCustomCountersConfig = new CustomCounterConfiguration();
             }
 
             newCounters.TwitchUserId = userId;

--- a/OmniForge.DotNet/tests/OmniForge.Tests/Services/GameSwitchServiceHandleGameDetectedMoreTests.cs
+++ b/OmniForge.DotNet/tests/OmniForge.Tests/Services/GameSwitchServiceHandleGameDetectedMoreTests.cs
@@ -75,7 +75,11 @@ namespace OmniForge.Tests.Services
             gameChatCommandsRepository.Setup(r => r.SaveAsync("user1", "newGame", It.IsAny<ChatCommandConfiguration>())).Returns(Task.CompletedTask);
 
             gameCustomCountersConfigRepository.Setup(r => r.GetAsync("user1", "newGame")).ReturnsAsync((CustomCounterConfiguration?)null);
-            gameCustomCountersConfigRepository.Setup(r => r.SaveAsync("user1", "newGame", It.IsAny<CustomCounterConfiguration>())).Returns(Task.CompletedTask);
+            CustomCounterConfiguration? seededCustomCountersConfig = null;
+            gameCustomCountersConfigRepository
+                .Setup(r => r.SaveAsync("user1", "newGame", It.IsAny<CustomCounterConfiguration>()))
+                .Callback<string, string, CustomCounterConfiguration>((_, __, cfg) => seededCustomCountersConfig = cfg)
+                .Returns(Task.CompletedTask);
 
             gameCoreCountersConfigRepository.Setup(r => r.GetAsync("user1", "newGame")).ReturnsAsync((GameCoreCountersConfig?)null);
             gameCoreCountersConfigRepository.Setup(r => r.SaveAsync("user1", "newGame", It.IsAny<GameCoreCountersConfig>())).Returns(Task.CompletedTask);
@@ -106,6 +110,10 @@ namespace OmniForge.Tests.Services
             Assert.Equal("Old Category", savedPrevious!.LastCategoryName);
             Assert.Equal(5, savedPrevious.CustomCounters["kills"]);
             Assert.Equal(2, savedPrevious.CustomCounters["assists"]);
+
+            Assert.NotNull(seededCustomCountersConfig);
+            Assert.NotNull(seededCustomCountersConfig!.Counters);
+            Assert.Empty(seededCustomCountersConfig.Counters);
         }
 
         [Fact]

--- a/OmniForge.DotNet/tests/OmniForge.Tests/Services/GameSwitchServiceHandleGameDetectedPreviousGameTests.cs
+++ b/OmniForge.DotNet/tests/OmniForge.Tests/Services/GameSwitchServiceHandleGameDetectedPreviousGameTests.cs
@@ -134,7 +134,11 @@ namespace OmniForge.Tests.Services
             gameChatCommandsRepository.Setup(r => r.SaveAsync(userId, newGameId, It.IsAny<ChatCommandConfiguration>())).Returns(Task.CompletedTask);
 
             gameCustomCountersConfigRepository.Setup(r => r.GetAsync(userId, newGameId)).ReturnsAsync((CustomCounterConfiguration?)null);
-            gameCustomCountersConfigRepository.Setup(r => r.SaveAsync(userId, newGameId, It.IsAny<CustomCounterConfiguration>())).Returns(Task.CompletedTask);
+            CustomCounterConfiguration? seededCustomCountersConfig = null;
+            gameCustomCountersConfigRepository
+                .Setup(r => r.SaveAsync(userId, newGameId, It.IsAny<CustomCounterConfiguration>()))
+                .Callback<string, string, CustomCounterConfiguration>((_, __, cfg) => seededCustomCountersConfig = cfg)
+                .Returns(Task.CompletedTask);
 
             gameCoreCountersConfigRepository.Setup(r => r.GetAsync(userId, newGameId)).ReturnsAsync((GameCoreCountersConfig?)null);
             GameCoreCountersConfig? seededCoreSelection = null;
@@ -186,6 +190,10 @@ namespace OmniForge.Tests.Services
             Assert.False(seededCoreSelection.SwearsEnabled);
             Assert.True(seededCoreSelection.ScreamsEnabled);
             Assert.False(seededCoreSelection.BitsEnabled);
+
+            Assert.NotNull(seededCustomCountersConfig);
+            Assert.NotNull(seededCustomCountersConfig!.Counters);
+            Assert.Empty(seededCustomCountersConfig.Counters);
 
             Assert.NotNull(appliedCcls);
             Assert.Contains("Gambling", appliedCcls!);


### PR DESCRIPTION
## Summary
- Fixes a bug where a newly detected game could inherit the previous game’s custom counters config, causing counters to appear enabled when they shouldn’t.
- Adds regression tests to ensure new games seed an empty per-game custom counter config.

## Changes
- Update new-game custom counter config seeding to default to an empty config.
- Add test assertions verifying seeded per-game custom counters config is empty when missing.

## Test
- Ran focused unit tests for game switching (GameSwitchService handle game detected tests).